### PR TITLE
Fix flake8 warnings

### DIFF
--- a/pages/tests/run.py
+++ b/pages/tests/run.py
@@ -6,7 +6,6 @@ import dj_database_url
 import django
 from colour_runner.django_runner import ColourRunnerMixin
 from django.conf import settings
-from django.test.runner import DiscoverRunner
 
 
 settings.configure(
@@ -38,6 +37,10 @@ settings.configure(
 
 if django.VERSION >= (1, 7):
     django.setup()
+
+
+# DiscoverRunner requires `django.setup()` to have been called
+from django.test.runner import DiscoverRunner  # noqa
 
 
 class TestRunner(ColourRunnerMixin, DiscoverRunner):

--- a/pages/tests/run.py
+++ b/pages/tests/run.py
@@ -6,6 +6,7 @@ import dj_database_url
 import django
 from colour_runner.django_runner import ColourRunnerMixin
 from django.conf import settings
+from django.test.runner import DiscoverRunner
 
 
 settings.configure(
@@ -28,14 +29,11 @@ settings.configure(
         'django.contrib.admin',
     ),
     MIDDLEWARE_CLASSES=(),
-    PASSWORD_HASHERS = ('django.contrib.auth.hashers.MD5PasswordHasher',),
-    SITE_ID = 1,
+    PASSWORD_HASHERS=('django.contrib.auth.hashers.MD5PasswordHasher',),
+    SITE_ID=1,
     AUTH_USER_MODEL='tests.User',
     ROOT_URLCONF='pages.tests.urls',
 )
-
-
-from django.test.runner import DiscoverRunner
 
 
 if django.VERSION >= (1, 7):


### PR DESCRIPTION
* E251: unexpected spaces around keyword / parameter equals
* E402: module level import not at top of file